### PR TITLE
VEGA-447: Интегрировать vega-rb с vega-shell

### DIFF
--- a/src/App/AppView.tsx
+++ b/src/App/AppView.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BrowserRouter as Router, Redirect, Route, Switch } from 'react-router-dom';
+import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 import { Root as VegaRoot } from '@gpn-prototypes/vega-ui';
 
 import { PageLayout } from '../layouts/PageLayout';
@@ -9,32 +9,25 @@ import { ProjectsPage } from '../pages/projects';
 import './App.css';
 
 export const AppView = (): React.ReactElement => {
-  const content = (
-    <Router>
-      <Switch>
-        <Route exact path="/projects">
-          <PageLayout>
-            <ProjectsPage />
-          </PageLayout>
-        </Route>
-        <Route exact path="/projects/create">
-          <PageLayout>
-            <CreateProjectPage />
-          </PageLayout>
-        </Route>
-        <Route exact path="/projects/edit">
-          <PageLayout>
-            <EditProjectPage />
-          </PageLayout>
-        </Route>
-        <Redirect to="/projects" />
-      </Switch>
-    </Router>
-  );
-
   return (
-    <VegaRoot className="App__Wrapper" defaultTheme="dark">
-      <div className="App">{content}</div>
-    </VegaRoot>
+    <Router>
+      <Route
+        exact
+        path={['/projects', '/projects/create', '/projects/show/:project_id']}
+        render={() => (
+          <VegaRoot className="App__Wrapper" defaultTheme="dark">
+            <div className="App">
+              <PageLayout>
+                <Switch>
+                  <Route exact path="/projects" component={ProjectsPage} />
+                  <Route exact path="/projects/create" component={CreateProjectPage} />
+                  <Route exact path="/projects/show/:project_id" component={EditProjectPage} />
+                </Switch>
+              </PageLayout>
+            </div>
+          </VegaRoot>
+        )}
+      />
+    </Router>
   );
 };


### PR DESCRIPTION
## Задача
Задача в Jira CSSSR: https://jira.csssr.io/browse/VEGA-447
Ссылка на скрипт: http://VEGA-447.vega-sp.csssr.cloud/vega-sp.js

Jira issue: VEGA-447

## Описание изменений

В роутинге `single-spa` нельзя указать `exact`. Все роуты отрабатывают по префиксу `url.startsWith(routePath)`
Поэтому пришлось всегда рендерить `vega-sp`, а уже внутри донастроить роутер, который будет рендерить приложение только на нужные роуты

## Чек-лист

- [ ] PR: направлен в правильную ветку
- [ ] PR: назначен исполнитель PR и указаны нужные лейблы
- [ ] PR: проверен diff, ничего лишнего в PR не попало
- [ ] PR: есть описание изменений или приложена ссылка на задачу с описанием, оставлены пояснительные комментарии к diff
- [ ] JS: нет предупреждений и ошибок в консоли браузера
- [ ] Тесты: новый функционал и исправленные баги покрыты тестами
- [ ] Верстка: проверена с разным количеством контента

## Опционально

- [ ] PR: прилинкованы затронутые issue и связанные PR
- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем PR
- [ ] Коммиты: проименованы в соответствии с [правилами](../docs/commits-style.md)
