### PR TITLE
VEGA-654: Исправить возможность отправлять пробелы в качестве значения при создании и редактировании проекта

### DIFF
--- a/src/pages/project/CreateProjectPage.tsx
+++ b/src/pages/project/CreateProjectPage.tsx
@@ -78,14 +78,14 @@ export const CreateProjectPage: React.FC<PageProps> = () => {
     const updateProjectResult = await updateProject({
       variables: {
         vid: blankProjectId,
-        name: values.description.name,
+        name: values.description.name?.trim(),
         type: values.description.type,
         region:
           values.description.region && values.description.region !== 'NOT_SELECTED'
             ? values.description.region
             : undefined,
-        coordinates: values.description.coordinates,
-        description: values.description.description,
+        coordinates: values.description.coordinates?.trim() || undefined,
+        description: values.description.description?.trim() || undefined,
         yearStart: values.description.yearStart,
         status: ProjectStatusEnum.Unpublished,
         version: 1,

--- a/src/pages/project/EditProjectPage.tsx
+++ b/src/pages/project/EditProjectPage.tsx
@@ -67,14 +67,14 @@ export const EditProjectPage: React.FC<PageProps> = () => {
     const updateProjectResult = await updateProject({
       variables: {
         vid: projectId,
-        name: values.description.name,
+        name: values.description.name?.trim(),
         type: values.description.type,
         region:
           values.description.region && values.description.region !== 'NOT_SELECTED'
             ? values.description.region
             : null,
-        coordinates: values.description.coordinates || null,
-        description: values.description.description || null,
+        coordinates: values.description.coordinates?.trim() || null,
+        description: values.description.description?.trim() || null,
         yearStart: values.description.yearStart || null,
         status: ProjectStatusEnum.Unpublished,
         version: version || 1,


### PR DESCRIPTION
## Задача
Задача в Jira CSSSR: https://jira.csssr.io/browse/VEGA-654
Ссылка на скрипт: http://VEGA-654.vega-sp.csssr.cloud/vega-sp.js

## Описание изменений

## Чек-лист

- [ ] PR: направлен в правильную ветку
- [ ] PR: назначен исполнитель PR и указаны нужные лейблы
- [ ] PR: проверен diff, ничего лишнего в PR не попало
- [ ] PR: есть описание изменений или приложена ссылка на задачу с описанием, оставлены пояснительные комментарии к diff
- [ ] JS: нет предупреждений и ошибок в консоли браузера
- [ ] Тесты: новый функционал и исправленные баги покрыты тестами
- [ ] Верстка: проверена с разным количеством контента

## Опционально

- [ ] PR: прилинкованы затронутые issue и связанные PR
- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем PR
- [ ] Коммиты: проименованы в соответствии с [правилами](../docs/commits-style.md)
