### PR TITLE
VEGA-768: Восстановить трим пробелов в полях описания проекта при создании и редактировании

### DIFF
--- a/src/ui/features/projects/ProjectForm/ProjectForm.tsx
+++ b/src/ui/features/projects/ProjectForm/ProjectForm.tsx
@@ -51,7 +51,14 @@ export const ProjectForm: React.FC<FormProps> = (formProps) => {
 
   const submit = React.useCallback(
     (values: FormValues, formApi: FormApi<FormValues>) => {
-      return onSubmit(values, formApi).then((errors) => {
+      const data = {
+        ...values,
+        name: values.name?.trim(),
+        description: values.description?.trim(),
+        coordinates: values.coordinates?.trim(),
+      };
+
+      return onSubmit(data, formApi).then((errors) => {
         setHasUnsavedChanges(false);
         return errors;
       });


### PR DESCRIPTION
## Задача
Задача в Jira CSSSR: https://jira.csssr.io/browse/VEGA-768
Ссылка на скрипт: http://VEGA-768.vega-sp.csssr.cloud/vega-sp.js

Jira issue: VEGA-768

## Описание изменений

## Чек-лист

- [ ] PR: направлен в правильную ветку
- [ ] PR: назначен исполнитель PR и указаны нужные лейблы
- [ ] PR: проверен diff, ничего лишнего в PR не попало
- [ ] PR: есть описание изменений или приложена ссылка на задачу с описанием, оставлены пояснительные комментарии к diff
- [ ] JS: нет предупреждений и ошибок в консоли браузера
- [ ] Тесты: новый функционал и исправленные баги покрыты тестами
- [ ] Верстка: проверена с разным количеством контента

## Опционально

- [ ] PR: прилинкованы затронутые issue и связанные PR
- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем PR
- [ ] Коммиты: проименованы в соответствии с [правилами](../docs/commits-style.md)
