### PR TITLE
VEGA-834: Добавить data-test-id для текстов валидации

### DIFF
--- a/src/ui/core/TextField/TextField.css
+++ b/src/ui/core/TextField/TextField.css
@@ -1,0 +1,5 @@
+.VegaTextField {
+  &__ErrorText {
+    margin-top: var(--space-2xs);
+  }
+}

--- a/src/ui/core/TextField/TextField.tsx
+++ b/src/ui/core/TextField/TextField.tsx
@@ -1,51 +1,59 @@
 import React from 'react';
-import { Field, FieldMetaState, FieldProps, FieldRenderProps } from 'react-final-form';
-import { TextField as VegaTextField } from '@gpn-prototypes/vega-ui';
+import { FieldInputProps, FieldMetaState } from 'react-final-form';
+import { Text, TextField as BaseTextField } from '@gpn-prototypes/vega-ui';
+import cn from 'bem-cn';
 
-type VegaTextFieldProps = Omit<
-  React.ComponentProps<typeof VegaTextField>,
-  'defaultValue' | 'value' | 'state'
->;
-type FinalFormFieldProps = Pick<FieldProps<string, FieldRenderProps<string>>, 'validate' | 'value'>;
+import './TextField.css';
 
-interface TextFieldProps extends VegaTextFieldProps, FinalFormFieldProps {
+type BaseTextFieldProps = React.ComponentProps<typeof BaseTextField>;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type TextFieldProps<T = any> = {
   name: string;
-  validateOnTouched?: boolean;
-  permanentValidation?: boolean;
-}
+  placeholder: string;
+  input: FieldInputProps<T>;
+  meta: FieldMetaState<T>;
+  testId?: string;
+} & Partial<BaseTextFieldProps>;
 
-type TextFieldState = React.ComponentProps<typeof VegaTextField>['state'];
-
-type TextFieldMeta = FieldMetaState<string>;
+const cnTextField = cn('VegaTextField');
 
 export const TextField: React.FC<TextFieldProps> = (props) => {
-  const { validateOnTouched = false, permanentValidation, ...restProps } = props;
+  const { input, meta, name, placeholder, testId, ...rest } = props;
 
-  const getFieldState = (meta: TextFieldMeta): TextFieldState => {
-    const { error, touched, submitFailed } = meta;
-    if (error) {
-      if ((validateOnTouched && touched) || submitFailed || permanentValidation) {
-        return 'alert';
-      }
-    }
-    return undefined;
-  };
+  const submitErrorText =
+    meta.submitError && !meta.dirtySinceLastSubmit ? meta.submitError : undefined;
+  const showError = Boolean(meta.error || submitErrorText) && meta.submitFailed;
+  const errorText = meta.error || submitErrorText;
 
   return (
-    <Field
-      {...restProps}
-      render={({ input, meta, ...rest }): React.ReactNode => (
-        <VegaTextField
-          {...rest}
-          value={input.value}
-          name={input.name}
-          type={input.type}
-          onChange={({ e }): void => input.onChange(e)}
-          state={getFieldState(meta)}
-          onBlur={input.onBlur}
-          onFocus={input.onFocus}
-        />
+    <>
+      <BaseTextField
+        id={name}
+        size="s"
+        width="full"
+        name={input.name}
+        state={showError ? 'alert' : undefined}
+        placeholder={placeholder}
+        autoComplete="off"
+        value={input.value}
+        onChange={({ e }): void => input.onChange(e)}
+        onBlur={input.onBlur}
+        onFocus={input.onFocus}
+        data-testid={testId}
+        {...rest}
+      />
+      {showError && (
+        <Text
+          size="xs"
+          lineHeight="xs"
+          view="alert"
+          className={cnTextField('ErrorText').toString()}
+          data-testid={testId ? `${testId}:error` : undefined}
+        >
+          {errorText}
+        </Text>
       )}
-    />
+    </>
   );
 };

--- a/src/ui/features/projects/ProjectForm/ProjectForm.css
+++ b/src/ui/features/projects/ProjectForm/ProjectForm.css
@@ -56,10 +56,6 @@
 .ProjectForm-DescriptionStep {
   width: 480px;
 
-  &__ErrorText {
-    margin-top: var(--space-2xs);
-  }
-
   &__ComboboxError .Select-Control {
     border-color: var(--color-bg-alert);
   }

--- a/src/ui/features/projects/ProjectForm/steps/DescriptionStep/DescriptionStep.tsx
+++ b/src/ui/features/projects/ProjectForm/steps/DescriptionStep/DescriptionStep.tsx
@@ -1,17 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { useState } from 'react';
-import { Field, FieldInputProps, FieldMetaState } from 'react-final-form';
-import { TextFieldProps as BaseTextFieldProps } from '@consta/uikit/TextField';
-import {
-  Combobox,
-  Form as VegaForm,
-  Text,
-  TextField as BaseTextField,
-} from '@gpn-prototypes/vega-ui';
+import { Field } from 'react-final-form';
+import { Combobox, Form as VegaForm, Text } from '@gpn-prototypes/vega-ui';
 import { FormApi } from 'final-form';
 
 import { ProjectTypeEnum } from '../../../../../../__generated__/types';
 import { ReferenceDataType } from '../../../../../../pages/project/types';
+import { TextField } from '../../../../../core';
 import { cnDescriptionStep, cnProjectForm } from '../../cn-form';
 import { FormMode, FormValues } from '../../types';
 
@@ -46,57 +41,9 @@ const getYearStartOptions = (): SelectOption[] => {
   return options;
 };
 
-type TextFieldProps<T = any> = {
-  name: string;
-  placeholder: string;
-  input: FieldInputProps<T>;
-  meta: FieldMetaState<T>;
-  testId?: string;
-} & Partial<BaseTextFieldProps>;
-
-const TextField: React.FC<TextFieldProps> = (props) => {
-  const { input, meta, name, placeholder, testId, ...rest } = props;
-
-  const submitErrorText =
-    meta.submitError && !meta.dirtySinceLastSubmit ? meta.submitError : undefined;
-  const showError = Boolean(meta.error || submitErrorText) && meta.submitFailed;
-  const errorText = meta.error || submitErrorText;
-
-  return (
-    <>
-      <BaseTextField
-        id={name}
-        size="s"
-        width="full"
-        name={input.name}
-        state={showError ? 'alert' : undefined}
-        placeholder={placeholder}
-        autoComplete="off"
-        value={input.value}
-        onChange={({ e }): void => input.onChange(e)}
-        onBlur={input.onBlur}
-        onFocus={input.onFocus}
-        data-testid={testId}
-        {...rest}
-      />
-      {showError && (
-        <Text
-          size="xs"
-          lineHeight="xs"
-          view="alert"
-          className={cnDescriptionStep('ErrorText').toString()}
-          data-testid={`${testId}:error`}
-        >
-          {errorText}
-        </Text>
-      )}
-    </>
-  );
-};
-
 const isValidYear = (str: string): boolean => /^\d{4}$/.test(str);
 
-const testID = {
+const testId = {
   name: 'ProjectForm:field:name',
   nameLabel: 'ProjectForm:label:name',
   region: 'ProjectForm:field:region',
@@ -149,7 +96,7 @@ export const DescriptionStep: React.FC<StepProps> = (props) => {
     <div className={cnProjectForm('Step').mix(cnDescriptionStep())}>
       <VegaForm.Row space="m">
         <VegaForm.Field>
-          <VegaForm.Label htmlFor="name" space="2xs" data-testid={testID.nameLabel}>
+          <VegaForm.Label htmlFor="name" space="2xs" data-testid={testId.nameLabel}>
             Название проекта
           </VegaForm.Label>
           <Field
@@ -161,7 +108,7 @@ export const DescriptionStep: React.FC<StepProps> = (props) => {
                   meta={meta}
                   name="name"
                   placeholder="Придумайте название проекта"
-                  testId={testID.name}
+                  testId={testId.name}
                 />
               );
             }}
@@ -170,7 +117,7 @@ export const DescriptionStep: React.FC<StepProps> = (props) => {
       </VegaForm.Row>
       <VegaForm.Row space="m">
         <VegaForm.Field>
-          <VegaForm.Label htmlFor="region" space="2xs" data-testid={testID.regionLabel}>
+          <VegaForm.Label htmlFor="region" space="2xs" data-testid={testId.regionLabel}>
             Регион
           </VegaForm.Label>
           <Field
@@ -194,7 +141,7 @@ export const DescriptionStep: React.FC<StepProps> = (props) => {
                 }}
                 onBlur={input.onBlur}
                 onFocus={input.onFocus}
-                data-testid={testID.region}
+                data-testid={testId.region}
               />
             )}
           />
@@ -202,7 +149,7 @@ export const DescriptionStep: React.FC<StepProps> = (props) => {
       </VegaForm.Row>
       <VegaForm.Row space="m">
         <VegaForm.Field>
-          <VegaForm.Label htmlFor="type" space="2xs" data-testid={testID.typeLabel}>
+          <VegaForm.Label htmlFor="type" space="2xs" data-testid={testId.typeLabel}>
             Тип проекта
           </VegaForm.Label>
           <Field
@@ -222,7 +169,7 @@ export const DescriptionStep: React.FC<StepProps> = (props) => {
                 }}
                 onBlur={input.onBlur}
                 onFocus={input.onFocus}
-                data-testid={testID.type}
+                data-testid={testId.type}
               />
             )}
           />
@@ -230,7 +177,7 @@ export const DescriptionStep: React.FC<StepProps> = (props) => {
       </VegaForm.Row>
       <VegaForm.Row space="m">
         <VegaForm.Field>
-          <VegaForm.Label htmlFor="coordinates" space="2xs" data-testid={testID.coordinatesLabel}>
+          <VegaForm.Label htmlFor="coordinates" space="2xs" data-testid={testId.coordinatesLabel}>
             Система координат
           </VegaForm.Label>
           <Field
@@ -244,7 +191,7 @@ export const DescriptionStep: React.FC<StepProps> = (props) => {
                   meta={meta}
                   name="coordinates"
                   placeholder="Укажите систему координат"
-                  testId={testID.coordinates}
+                  testId={testId.coordinates}
                 />
               );
             }}
@@ -253,7 +200,7 @@ export const DescriptionStep: React.FC<StepProps> = (props) => {
       </VegaForm.Row>
       <VegaForm.Row space="m">
         <VegaForm.Field>
-          <VegaForm.Label htmlFor="yearStart" space="2xs" data-testid={testID.yearStartLabel}>
+          <VegaForm.Label htmlFor="yearStart" space="2xs" data-testid={testId.yearStartLabel}>
             Год начала планирования
           </VegaForm.Label>
           <Field
@@ -294,7 +241,7 @@ export const DescriptionStep: React.FC<StepProps> = (props) => {
                     }}
                     onBlur={input.onBlur}
                     onFocus={input.onFocus}
-                    data-testid={testID.yearStart}
+                    data-testid={testId.yearStart}
                   />
                   {showError && (
                     <Text
@@ -302,7 +249,7 @@ export const DescriptionStep: React.FC<StepProps> = (props) => {
                       lineHeight="xs"
                       view="alert"
                       className={cnDescriptionStep('ErrorText').toString()}
-                      data-testid={`${testID.yearStart}:error`}
+                      data-testid={`${testId.yearStart}:error`}
                     >
                       {errorText}
                     </Text>
@@ -315,7 +262,7 @@ export const DescriptionStep: React.FC<StepProps> = (props) => {
       </VegaForm.Row>
       <VegaForm.Row space="m">
         <VegaForm.Field>
-          <VegaForm.Label htmlFor="description" space="2xs" data-testid={testID.descriptionLabel}>
+          <VegaForm.Label htmlFor="description" space="2xs" data-testid={testId.descriptionLabel}>
             Описание проекта
           </VegaForm.Label>
           <Field
@@ -334,7 +281,7 @@ export const DescriptionStep: React.FC<StepProps> = (props) => {
                 size="s"
                 width="full"
                 placeholder="Краткое описание проекта поможет отличать ваши проекты среди остальных и находить похожие"
-                testId={testID.description}
+                testId={testId.description}
               />
             )}
           />

--- a/src/ui/features/projects/ProjectForm/steps/DescriptionStep/DescriptionStep.tsx
+++ b/src/ui/features/projects/ProjectForm/steps/DescriptionStep/DescriptionStep.tsx
@@ -107,7 +107,6 @@ const testId = {
   typeLabel: 'ProjectForm:label:type',
   yearStart: 'ProjectForm:field:yearStart',
   yearStartLabel: 'ProjectForm:label:yearStart',
-  yearStartError: 'ProjectForm:text:yearStart:error',
   description: 'ProjectForm:field:description',
   descriptionLabel: 'ProjectForm:label:description',
 };
@@ -303,7 +302,7 @@ export const DescriptionStep: React.FC<StepProps> = (props) => {
                       lineHeight="xs"
                       view="alert"
                       className={cnDescriptionStep('ErrorText').toString()}
-                      data-testid={testId.yearStartError}
+                      data-testid={`${testId.yearStart}:error`}
                     >
                       {errorText}
                     </Text>

--- a/src/ui/features/projects/ProjectForm/steps/DescriptionStep/DescriptionStep.tsx
+++ b/src/ui/features/projects/ProjectForm/steps/DescriptionStep/DescriptionStep.tsx
@@ -51,11 +51,11 @@ type TextFieldProps<T = any> = {
   placeholder: string;
   input: FieldInputProps<T>;
   meta: FieldMetaState<T>;
-  errorTestId?: string;
+  testId?: string;
 } & Partial<BaseTextFieldProps>;
 
 const TextField: React.FC<TextFieldProps> = (props) => {
-  const { input, meta, name, placeholder, errorTestId, ...rest } = props;
+  const { input, meta, name, placeholder, testId, ...rest } = props;
 
   const submitErrorText =
     meta.submitError && !meta.dirtySinceLastSubmit ? meta.submitError : undefined;
@@ -76,6 +76,7 @@ const TextField: React.FC<TextFieldProps> = (props) => {
         onChange={({ e }): void => input.onChange(e)}
         onBlur={input.onBlur}
         onFocus={input.onFocus}
+        data-testid={testId}
         {...rest}
       />
       {showError && (
@@ -84,7 +85,7 @@ const TextField: React.FC<TextFieldProps> = (props) => {
           lineHeight="xs"
           view="alert"
           className={cnDescriptionStep('ErrorText').toString()}
-          data-testid={errorTestId}
+          data-testid={`${testId}:error`}
         >
           {errorText}
         </Text>
@@ -98,20 +99,17 @@ const isValidYear = (str: string): boolean => /^\d{4}$/.test(str);
 const testId = {
   name: 'ProjectForm:field:name',
   nameLabel: 'ProjectForm:label:name',
-  nameError: 'ProjectForm:text:error.name',
   region: 'ProjectForm:field:region',
   regionLabel: 'ProjectForm:label:region',
   coordinates: 'ProjectForm:field:coordinates',
   coordinatesLabel: 'ProjectForm:label:coordinates',
-  coordinatesError: 'ProjectForm:text:error:coordinates',
   type: 'ProjectForm:field:type',
   typeLabel: 'ProjectForm:label:type',
   yearStart: 'ProjectForm:field:yearStart',
   yearStartLabel: 'ProjectForm:label:yearStart',
-  yearStartError: 'ProjectForm:text:error:yearStart',
+  yearStartError: 'ProjectForm:text:yearStart:error',
   description: 'ProjectForm:field:description',
   descriptionLabel: 'ProjectForm:label:description',
-  descriptionError: 'ProjectForm:text:error:description',
 };
 
 export const DescriptionStep: React.FC<StepProps> = (props) => {
@@ -164,8 +162,7 @@ export const DescriptionStep: React.FC<StepProps> = (props) => {
                   meta={meta}
                   name="name"
                   placeholder="Придумайте название проекта"
-                  data-testid={testId.name}
-                  errorTestId={testId.nameError}
+                  testId={testId.name}
                 />
               );
             }}
@@ -248,8 +245,7 @@ export const DescriptionStep: React.FC<StepProps> = (props) => {
                   meta={meta}
                   name="coordinates"
                   placeholder="Укажите систему координат"
-                  data-testid={testId.coordinates}
-                  errorTestId={testId.coordinatesError}
+                  testId={testId.coordinates}
                 />
               );
             }}
@@ -339,8 +335,7 @@ export const DescriptionStep: React.FC<StepProps> = (props) => {
                 size="s"
                 width="full"
                 placeholder="Краткое описание проекта поможет отличать ваши проекты среди остальных и находить похожие"
-                data-testid={testId.description}
-                errorTestId={testId.descriptionError}
+                testId={testId.description}
               />
             )}
           />

--- a/src/ui/features/projects/ProjectForm/steps/DescriptionStep/DescriptionStep.tsx
+++ b/src/ui/features/projects/ProjectForm/steps/DescriptionStep/DescriptionStep.tsx
@@ -96,7 +96,7 @@ const TextField: React.FC<TextFieldProps> = (props) => {
 
 const isValidYear = (str: string): boolean => /^\d{4}$/.test(str);
 
-const testId = {
+const testID = {
   name: 'ProjectForm:field:name',
   nameLabel: 'ProjectForm:label:name',
   region: 'ProjectForm:field:region',
@@ -149,7 +149,7 @@ export const DescriptionStep: React.FC<StepProps> = (props) => {
     <div className={cnProjectForm('Step').mix(cnDescriptionStep())}>
       <VegaForm.Row space="m">
         <VegaForm.Field>
-          <VegaForm.Label htmlFor="name" space="2xs" data-testid={testId.nameLabel}>
+          <VegaForm.Label htmlFor="name" space="2xs" data-testid={testID.nameLabel}>
             Название проекта
           </VegaForm.Label>
           <Field
@@ -161,7 +161,7 @@ export const DescriptionStep: React.FC<StepProps> = (props) => {
                   meta={meta}
                   name="name"
                   placeholder="Придумайте название проекта"
-                  testId={testId.name}
+                  testId={testID.name}
                 />
               );
             }}
@@ -170,7 +170,7 @@ export const DescriptionStep: React.FC<StepProps> = (props) => {
       </VegaForm.Row>
       <VegaForm.Row space="m">
         <VegaForm.Field>
-          <VegaForm.Label htmlFor="region" space="2xs" data-testid={testId.regionLabel}>
+          <VegaForm.Label htmlFor="region" space="2xs" data-testid={testID.regionLabel}>
             Регион
           </VegaForm.Label>
           <Field
@@ -194,7 +194,7 @@ export const DescriptionStep: React.FC<StepProps> = (props) => {
                 }}
                 onBlur={input.onBlur}
                 onFocus={input.onFocus}
-                data-testid={testId.region}
+                data-testid={testID.region}
               />
             )}
           />
@@ -202,7 +202,7 @@ export const DescriptionStep: React.FC<StepProps> = (props) => {
       </VegaForm.Row>
       <VegaForm.Row space="m">
         <VegaForm.Field>
-          <VegaForm.Label htmlFor="type" space="2xs" data-testid={testId.typeLabel}>
+          <VegaForm.Label htmlFor="type" space="2xs" data-testid={testID.typeLabel}>
             Тип проекта
           </VegaForm.Label>
           <Field
@@ -222,7 +222,7 @@ export const DescriptionStep: React.FC<StepProps> = (props) => {
                 }}
                 onBlur={input.onBlur}
                 onFocus={input.onFocus}
-                data-testid={testId.type}
+                data-testid={testID.type}
               />
             )}
           />
@@ -230,7 +230,7 @@ export const DescriptionStep: React.FC<StepProps> = (props) => {
       </VegaForm.Row>
       <VegaForm.Row space="m">
         <VegaForm.Field>
-          <VegaForm.Label htmlFor="coordinates" space="2xs" data-testid={testId.coordinatesLabel}>
+          <VegaForm.Label htmlFor="coordinates" space="2xs" data-testid={testID.coordinatesLabel}>
             Система координат
           </VegaForm.Label>
           <Field
@@ -244,7 +244,7 @@ export const DescriptionStep: React.FC<StepProps> = (props) => {
                   meta={meta}
                   name="coordinates"
                   placeholder="Укажите систему координат"
-                  testId={testId.coordinates}
+                  testId={testID.coordinates}
                 />
               );
             }}
@@ -253,7 +253,7 @@ export const DescriptionStep: React.FC<StepProps> = (props) => {
       </VegaForm.Row>
       <VegaForm.Row space="m">
         <VegaForm.Field>
-          <VegaForm.Label htmlFor="yearStart" space="2xs" data-testid={testId.yearStartLabel}>
+          <VegaForm.Label htmlFor="yearStart" space="2xs" data-testid={testID.yearStartLabel}>
             Год начала планирования
           </VegaForm.Label>
           <Field
@@ -294,7 +294,7 @@ export const DescriptionStep: React.FC<StepProps> = (props) => {
                     }}
                     onBlur={input.onBlur}
                     onFocus={input.onFocus}
-                    data-testid={testId.yearStart}
+                    data-testid={testID.yearStart}
                   />
                   {showError && (
                     <Text
@@ -302,7 +302,7 @@ export const DescriptionStep: React.FC<StepProps> = (props) => {
                       lineHeight="xs"
                       view="alert"
                       className={cnDescriptionStep('ErrorText').toString()}
-                      data-testid={`${testId.yearStart}:error`}
+                      data-testid={`${testID.yearStart}:error`}
                     >
                       {errorText}
                     </Text>
@@ -315,7 +315,7 @@ export const DescriptionStep: React.FC<StepProps> = (props) => {
       </VegaForm.Row>
       <VegaForm.Row space="m">
         <VegaForm.Field>
-          <VegaForm.Label htmlFor="description" space="2xs" data-testid={testId.descriptionLabel}>
+          <VegaForm.Label htmlFor="description" space="2xs" data-testid={testID.descriptionLabel}>
             Описание проекта
           </VegaForm.Label>
           <Field
@@ -334,7 +334,7 @@ export const DescriptionStep: React.FC<StepProps> = (props) => {
                 size="s"
                 width="full"
                 placeholder="Краткое описание проекта поможет отличать ваши проекты среди остальных и находить похожие"
-                testId={testId.description}
+                testId={testID.description}
               />
             )}
           />

--- a/src/ui/features/projects/ProjectForm/steps/DescriptionStep/DescriptionStep.tsx
+++ b/src/ui/features/projects/ProjectForm/steps/DescriptionStep/DescriptionStep.tsx
@@ -51,10 +51,11 @@ type TextFieldProps<T = any> = {
   placeholder: string;
   input: FieldInputProps<T>;
   meta: FieldMetaState<T>;
+  errorTestId?: string;
 } & Partial<BaseTextFieldProps>;
 
 const TextField: React.FC<TextFieldProps> = (props) => {
-  const { input, meta, name, placeholder, ...rest } = props;
+  const { input, meta, name, placeholder, errorTestId, ...rest } = props;
 
   const submitErrorText =
     meta.submitError && !meta.dirtySinceLastSubmit ? meta.submitError : undefined;
@@ -83,6 +84,7 @@ const TextField: React.FC<TextFieldProps> = (props) => {
           lineHeight="xs"
           view="alert"
           className={cnDescriptionStep('ErrorText').toString()}
+          data-testid={errorTestId}
         >
           {errorText}
         </Text>
@@ -101,12 +103,15 @@ const testId = {
   regionLabel: 'ProjectForm:label:region',
   coordinates: 'ProjectForm:field:coordinates',
   coordinatesLabel: 'ProjectForm:label:coordinates',
+  coordinatesError: 'ProjectForm:text:error:coordinates',
   type: 'ProjectForm:field:type',
   typeLabel: 'ProjectForm:label:type',
   yearStart: 'ProjectForm:field:yearStart',
   yearStartLabel: 'ProjectForm:label:yearStart',
+  yearStartError: 'ProjectForm:text:error:yearStart',
   description: 'ProjectForm:field:description',
   descriptionLabel: 'ProjectForm:label:description',
+  descriptionError: 'ProjectForm:text:error:description',
 };
 
 export const DescriptionStep: React.FC<StepProps> = (props) => {
@@ -160,6 +165,7 @@ export const DescriptionStep: React.FC<StepProps> = (props) => {
                   name="name"
                   placeholder="Придумайте название проекта"
                   data-testid={testId.name}
+                  errorTestId={testId.nameError}
                 />
               );
             }}
@@ -243,6 +249,7 @@ export const DescriptionStep: React.FC<StepProps> = (props) => {
                   name="coordinates"
                   placeholder="Укажите систему координат"
                   data-testid={testId.coordinates}
+                  errorTestId={testId.coordinatesError}
                 />
               );
             }}
@@ -300,6 +307,7 @@ export const DescriptionStep: React.FC<StepProps> = (props) => {
                       lineHeight="xs"
                       view="alert"
                       className={cnDescriptionStep('ErrorText').toString()}
+                      data-testid={testId.yearStartError}
                     >
                       {errorText}
                     </Text>
@@ -332,6 +340,7 @@ export const DescriptionStep: React.FC<StepProps> = (props) => {
                 width="full"
                 placeholder="Краткое описание проекта поможет отличать ваши проекты среди остальных и находить похожие"
                 data-testid={testId.description}
+                errorTestId={testId.descriptionError}
               />
             )}
           />


### PR DESCRIPTION
## Задача
Задача в Jira CSSSR: https://jira.csssr.io/browse/VEGA-834
Ссылка на скрипт: http://VEGA-834.vega-sp.csssr.cloud/vega-sp.js

Jira issue: VEGA-834

## Описание изменений

## Чек-лист

- [ ] PR: направлен в правильную ветку
- [ ] PR: назначен исполнитель PR и указаны нужные лейблы
- [ ] PR: проверен diff, ничего лишнего в PR не попало
- [ ] PR: есть описание изменений или приложена ссылка на задачу с описанием, оставлены пояснительные комментарии к diff
- [ ] JS: нет предупреждений и ошибок в консоли браузера
- [ ] Тесты: новый функционал и исправленные баги покрыты тестами
- [ ] Верстка: проверена с разным количеством контента

## Опционально

- [ ] PR: прилинкованы затронутые issue и связанные PR
- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем PR
- [ ] Коммиты: проименованы в соответствии с [правилами](../docs/commits-style.md)
