### PR TITLE
VEGA-817: Покрыть тестами хук useBrowserTabActivity

### DIFF
--- a/src/hooks/use-browser-tab-activity.test.tsx
+++ b/src/hooks/use-browser-tab-activity.test.tsx
@@ -1,0 +1,137 @@
+import React from 'react';
+import { render, RenderResult } from '@testing-library/react';
+
+import { InputObserver, useBrowserTabActivity } from './use-browser-tab-activity';
+
+type ComponentProps = {
+  observer: InputObserver;
+};
+
+const eventNamesMap = {
+  focus: ['onFocus', 'onActivated'],
+  blur: ['onBlur', 'onDeactivated'],
+};
+
+const TestComponent = (props: ComponentProps): React.ReactElement | null => {
+  useBrowserTabActivity(props.observer);
+
+  return <div>test-component</div>;
+};
+
+const changeVisibilityState = (state: VisibilityState): void => {
+  Object.defineProperty(global.document, 'visibilityState', {
+    value: state,
+    configurable: true,
+  });
+  global.document.dispatchEvent(new Event('visibilitychange'));
+};
+
+afterEach(() => {
+  jest.clearAllMocks();
+  changeVisibilityState('visible');
+});
+
+const renderComponent = (props: ComponentProps): RenderResult => {
+  return render(<TestComponent {...props} />);
+};
+
+describe('useBrowserTabActivity', () => {
+  describe('срабатывание слушателей при изменении видимости таба', () => {
+    test.each(['onVisible', 'onActivated'])('при становлении таба видимым вызывается %s', (key) => {
+      const handleVisible = jest.fn();
+
+      renderComponent({ observer: { [key]: handleVisible } });
+
+      changeVisibilityState('visible');
+
+      expect(handleVisible).toBeCalledTimes(1);
+    });
+
+    test.each(['onHidden', 'onDeactivated'])('при скрытии таба вызывается %s', (key) => {
+      const handleHidden = jest.fn();
+
+      renderComponent({ observer: { [key]: handleHidden } });
+
+      changeVisibilityState('hidden');
+
+      expect(handleHidden).toBeCalledTimes(1);
+    });
+
+    test.each(['onVisibilityChange', 'onActivityChange'])(
+      'при смене состояния таба вызывается %s',
+      (key) => {
+        const handleVisibilityChange = jest.fn();
+
+        renderComponent({ observer: { [key]: handleVisibilityChange } });
+
+        changeVisibilityState('visible');
+
+        expect(handleVisibilityChange).toBeCalledWith({
+          visible: true,
+          hidden: false,
+          focus: true,
+          blur: false,
+        });
+
+        changeVisibilityState('hidden');
+
+        expect(handleVisibilityChange).toBeCalledWith({
+          visible: false,
+          hidden: true,
+          focus: true,
+          blur: false,
+        });
+      },
+    );
+  });
+
+  describe.each(Object.keys(eventNamesMap))(
+    'срабатывание слушателей при событии %s',
+    (eventName) => {
+      const eventNames = eventNamesMap[eventName as 'blur' | 'focus'];
+
+      test.each(eventNames)(`при событии ${eventName} вызывается %s`, (key) => {
+        const handleEvent = jest.fn();
+
+        renderComponent({ observer: { [key]: handleEvent } });
+
+        global.dispatchEvent(new Event(eventName));
+
+        expect(handleEvent).toBeCalledTimes(1);
+      });
+
+      test(`при событии ${eventName} вызывается onActivityChange`, () => {
+        const handleActivityChange = jest.fn();
+
+        renderComponent({ observer: { onActivityChange: handleActivityChange } });
+
+        global.dispatchEvent(new Event(eventName));
+
+        expect(handleActivityChange).toBeCalledWith({
+          visible: true,
+          hidden: false,
+          blur: eventName === 'blur',
+          focus: eventName === 'focus',
+        });
+      });
+    },
+  );
+
+  test('функция-обозреватель вызывается при изменении состояния', () => {
+    const handleActivityChange = jest.fn();
+
+    renderComponent({ observer: handleActivityChange });
+
+    changeVisibilityState('hidden');
+
+    expect(handleActivityChange).toBeCalledTimes(1);
+
+    global.dispatchEvent(new Event('focus'));
+
+    expect(handleActivityChange).toBeCalledTimes(2);
+
+    global.dispatchEvent(new Event('blur'));
+
+    expect(handleActivityChange).toBeCalledTimes(3);
+  });
+});

--- a/src/hooks/use-browser-tab-activity.ts
+++ b/src/hooks/use-browser-tab-activity.ts
@@ -3,19 +3,19 @@ import { merge } from 'ramda';
 
 const noop = () => {};
 
-interface State {
+export interface State {
   visible: boolean;
   hidden: boolean;
   focus: boolean;
   blur: boolean;
 }
 
-interface InnerState {
+export interface InnerState {
   visible: boolean;
   active: boolean;
 }
 
-interface Observer {
+export interface Observer {
   onVisible(): void;
   onHidden(): void;
   onActivated(): void;
@@ -37,15 +37,17 @@ const withDefaulHandlers = merge({
   onVisibilityChange: noop,
 });
 
+export type InputObserver = Partial<Observer> | VoidFunction;
+
 const defaultObserver = withDefaulHandlers({});
 
-function useObserverRef(observer: Partial<Observer>): React.MutableRefObject<Observer> {
+export function useObserverRef(observer: InputObserver): React.MutableRefObject<Observer> {
   const result = useRef<Observer>(defaultObserver);
 
   result.current =
     typeof observer !== 'function'
       ? withDefaulHandlers(observer)
-      : withDefaulHandlers({ onChange: observer });
+      : withDefaulHandlers({ onActivityChange: observer });
 
   return result;
 }
@@ -59,7 +61,7 @@ function computeState(state: InnerState): State {
   };
 }
 
-export function useBrowserTabActivity(inputObserver: Partial<Observer>): void {
+export function useBrowserTabActivity(inputObserver: InputObserver): void {
   const stateRef = useRef<InnerState>({
     visible: true,
     active: true,


### PR DESCRIPTION
## Задача
Задача в Jira CSSSR: https://jira.csssr.io/browse/VEGA-817
Ссылка на скрипт: http://VEGA-817.vega-sp.csssr.cloud/vega-sp.js

Jira issue: VEGA-817

## Описание изменений

## Чек-лист

- [x] PR: направлен в правильную ветку
- [x] PR: назначен исполнитель PR и указаны нужные лейблы
- [x] PR: проверен diff, ничего лишнего в PR не попало
- [ ] PR: есть описание изменений или приложена ссылка на задачу с описанием, оставлены пояснительные комментарии к diff
- [x] JS: нет предупреждений и ошибок в консоли браузера
- [ ] Тесты: новый функционал и исправленные баги покрыты тестами
- [ ] Верстка: проверена с разным количеством контента

## Опционально

- [ ] PR: прилинкованы затронутые issue и связанные PR
- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем PR
- [ ] Коммиты: проименованы в соответствии с [правилами](../docs/commits-style.md)
