### PR TITLE
VEGA-854: Сделать всегда активной кнопку сабмита на формах создания и редактирования проекта

### DIFF
--- a/src/ui/core/TextField/TextField.tsx
+++ b/src/ui/core/TextField/TextField.tsx
@@ -23,7 +23,7 @@ export const TextField: React.FC<TextFieldProps> = (props) => {
 
   const submitErrorText =
     meta.submitError && !meta.dirtySinceLastSubmit ? meta.submitError : undefined;
-  const showError = Boolean(meta.error || submitErrorText) && !meta.pristine;
+  const showError = (Boolean(meta.error || submitErrorText) && meta.submitFailed) || !meta.pristine;
   const errorText = meta.error || submitErrorText;
 
   return (

--- a/src/ui/features/projects/ProjectForm/Footer.tsx
+++ b/src/ui/features/projects/ProjectForm/Footer.tsx
@@ -23,7 +23,7 @@ const testId = {
   saveEdit: 'ProjectForm:button:save.edit',
   nextStep: 'ProjectForm:button:nextStep',
   prevStep: 'ProjectForm:button:prevStep',
-  createButton: 'ProjectForm:button:сreate',
+  createButton: 'ProjectForm:button:create',
 } as const;
 
 type FooterType = React.FC<FooterProps> & {
@@ -47,15 +47,7 @@ export const Footer: FooterType = (props) => {
     onStepChange(activeStep - 1);
   };
 
-  const {
-    valid,
-    dirtySinceLastSubmit,
-    hasValidationErrors,
-    hasSubmitErrors,
-    dirty,
-  } = form.getState();
-
-  const isSubmitButtonDisabled = (!valid && !dirtySinceLastSubmit) || hasValidationErrors;
+  const { valid, dirtySinceLastSubmit, hasSubmitErrors, dirty } = form.getState();
 
   const createProjectFormFooter = (
     <PageFooter
@@ -104,7 +96,6 @@ export const Footer: FooterType = (props) => {
               form.change('status', ProjectStatusEnum.Unpublished);
             }}
             data-testId={testId.createButton}
-            disabled={isSubmitButtonDisabled}
           />
         )}
       </div>
@@ -127,7 +118,6 @@ export const Footer: FooterType = (props) => {
         view="primary"
         label="Сохранить изменения"
         type="submit"
-        disabled={isSubmitButtonDisabled}
         data-testid={testId.saveEdit}
       />
     </PageFooter>

--- a/src/ui/features/projects/ProjectForm/steps/DescriptionStep/DescriptionStep.tsx
+++ b/src/ui/features/projects/ProjectForm/steps/DescriptionStep/DescriptionStep.tsx
@@ -210,7 +210,8 @@ export const DescriptionStep: React.FC<StepProps> = (props) => {
               const submitErrorText =
                 meta.submitError && !meta.dirtySinceLastSubmit ? meta.submitError : undefined;
               const showError =
-                Boolean(meta.error || submitErrorText) && (meta.touched || meta.submitFailed);
+                Boolean(meta.error || submitErrorText) &&
+                (meta.touched || meta.submitFailed || meta.dirty);
               const errorText = meta.error || submitErrorText;
 
               return (


### PR DESCRIPTION
## Задача
Задача в Jira CSSSR: https://jira.csssr.io/browse/VEGA-854
Ссылка на скрипт: http://VEGA-854.vega-sp.csssr.cloud/vega-sp.js

## Описание изменений

## Чек-лист

- [x] PR: направлен в правильную ветку
- [x] PR: назначен исполнитель PR и указаны нужные лейблы
- [x] PR: проверен diff, ничего лишнего в PR не попало
- [ ] PR: есть описание изменений или приложена ссылка на задачу с описанием, оставлены пояснительные комментарии к diff
- [ ] JS: нет предупреждений и ошибок в консоли браузера
- [ ] Тесты: новый функционал и исправленные баги покрыты тестами
- [ ] Верстка: проверена с разным количеством контента

## Опционально

- [ ] PR: прилинкованы затронутые issue и связанные PR
- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем PR
- [x] Коммиты: проименованы в соответствии с [правилами](../docs/commits-style.md)
