### PR TITLE
VEGA-900: Восстановить сохранение черновика, если не задать имя проекта

### DIFF
--- a/src/ui/features/projects/ProjectForm/ProjectForm.tsx
+++ b/src/ui/features/projects/ProjectForm/ProjectForm.tsx
@@ -3,6 +3,7 @@ import { Form, FormSpy } from 'react-final-form';
 import { Form as VegaForm, NavigationList } from '@gpn-prototypes/vega-ui';
 import { FormApi, SubmissionErrors } from 'final-form';
 import createDecorator from 'final-form-focus';
+import { intersection } from 'ramda';
 
 import { ProjectStatusEnum } from '../../../../__generated__/types';
 import { createValidate, validators } from '../../../forms/validation';
@@ -105,8 +106,20 @@ export const ProjectForm: React.FC<FormProps> = (formProps) => {
   });
 
   const autoSave = (form: FormApi<FormValues>) => {
-    const { values, active, dirty, valid, validating, dirtySinceLastSubmit } = form.getState();
+    const {
+      values,
+      active,
+      dirty,
+      validating,
+      dirtySinceLastSubmit,
+      dirtyFields,
+      errors,
+    } = form.getState();
     const isBlurEvent = (state.active && state.active !== active) || !active;
+
+    const fieldsWithErrors = Object.keys(errors);
+    const fieldsDirty = Object.keys(dirtyFields);
+    const valid = intersection(fieldsWithErrors, fieldsDirty).length === 0;
 
     if (values.status === ProjectStatusEnum.Unpublished && active) {
       form.change('status', ProjectStatusEnum.Blank);


### PR DESCRIPTION
## Задача
Задача в Jira CSSSR: https://jira.csssr.io/browse/VEGA-900
Ссылка на скрипт: http://VEGA-900.vega-sp.csssr.cloud/vega-sp.js

## Описание изменений

## Чек-лист

- [x] PR: направлен в правильную ветку
- [x] PR: назначен исполнитель PR и указаны нужные лейблы
- [x] PR: проверен diff, ничего лишнего в PR не попало
- [ ] PR: есть описание изменений или приложена ссылка на задачу с описанием, оставлены пояснительные комментарии к diff
- [ ] JS: нет предупреждений и ошибок в консоли браузера
- [ ] Тесты: новый функционал и исправленные баги покрыты тестами
- [ ] Верстка: проверена с разным количеством контента

## Опционально

- [ ] PR: прилинкованы затронутые issue и связанные PR
- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем PR
- [x] Коммиты: проименованы в соответствии с [правилами](../docs/commits-style.md)
