### PR TITLE
VEGA-933: Исправить поведение футера при сохранении кастомного значения Год начала планирования

### DIFF
--- a/src/ui/features/projects/ProjectForm/steps/DescriptionStep/DescriptionStep.tsx
+++ b/src/ui/features/projects/ProjectForm/steps/DescriptionStep/DescriptionStep.tsx
@@ -235,7 +235,7 @@ export const DescriptionStep: DescriptionStepType = (props) => {
                         return;
                       }
                       updateYearStartOptions(option);
-                      input.onChange(option);
+                      input.onChange(Number(option));
                     }}
                     placeholder="Выберите год"
                     value={yearStartOptions.find(


### PR DESCRIPTION
## Задача
Задача в Jira CSSSR: https://jira.csssr.io/browse/VEGA-933
Ссылка на скрипт: http://VEGA-933.vega-sp.csssr.cloud/vega-sp.js

…ля "Год начала планирования"

Jira issue: VEGA-933

## Описание изменений

## Чек-лист

- [ ] PR: направлен в правильную ветку
- [ ] PR: назначен исполнитель PR и указаны нужные лейблы
- [ ] PR: проверен diff, ничего лишнего в PR не попало
- [ ] PR: есть описание изменений или приложена ссылка на задачу с описанием, оставлены пояснительные комментарии к diff
- [ ] JS: нет предупреждений и ошибок в консоли браузера
- [ ] Тесты: новый функционал и исправленные баги покрыты тестами
- [ ] Верстка: проверена с разным количеством контента

## Опционально

- [ ] PR: прилинкованы затронутые issue и связанные PR
- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем PR
- [ ] Коммиты: проименованы в соответствии с [правилами](../docs/commits-style.md)
