### PR TITLE
[VEGA-3402] fix(graphql): удаление localProject из UpdateProjectDiff

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -10441,22 +10441,10 @@
       {
         "kind": "OBJECT",
         "name": "UpdateProjectDiff",
-        "description": "Contains remote and local versions of  project if versions are not equal.",
+        "description": "Contains remote version of project if versions are not equal.",
         "fields": [
           {
             "name": "remoteProject",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "Project",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "localProject",
             "description": null,
             "args": [],
             "type": {
@@ -11766,11 +11754,7 @@
         "name": "skip",
         "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
         "isRepeatable": false,
-        "locations": [
-          "FIELD",
-          "FRAGMENT_SPREAD",
-          "INLINE_FRAGMENT"
-        ],
+        "locations": ["FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"],
         "args": [
           {
             "name": "if",
@@ -11792,11 +11776,7 @@
         "name": "include",
         "description": "Directs the executor to include this field or fragment only when the `if` argument is true.",
         "isRepeatable": false,
-        "locations": [
-          "FIELD",
-          "FRAGMENT_SPREAD",
-          "INLINE_FRAGMENT"
-        ],
+        "locations": ["FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"],
         "args": [
           {
             "name": "if",
@@ -11818,10 +11798,7 @@
         "name": "deprecated",
         "description": "Marks an element of a GraphQL schema as no longer supported.",
         "isRepeatable": false,
-        "locations": [
-          "FIELD_DEFINITION",
-          "ENUM_VALUE"
-        ],
+        "locations": ["FIELD_DEFINITION", "ENUM_VALUE"],
         "args": [
           {
             "name": "reason",
@@ -11839,9 +11816,7 @@
         "name": "specifiedBy",
         "description": "Exposes a URL that specifies the behaviour of this scalar.",
         "isRepeatable": false,
-        "locations": [
-          "SCALAR"
-        ],
+        "locations": ["SCALAR"],
         "args": [
           {
             "name": "url",

--- a/schema.graphql
+++ b/schema.graphql
@@ -962,7 +962,6 @@ union ProjectDiffOrError = Project | UpdateProjectDiff | Error | ValidationError
 """Contains remote and local versions of  project if versions are not equal."""
 type UpdateProjectDiff {
   remoteProject: Project
-  localProject: Project
   message: String
 }
 

--- a/src/pages/project/CreateProjectPage.test.tsx
+++ b/src/pages/project/CreateProjectPage.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { merge } from 'ramda';
 
 import { ErrorCodesEnum, ProjectStatusEnum, ProjectTypeEnum } from '../../__generated__/types';
-import { act, fireEvent, render, RenderResult, screen, waitRequests } from '../../testing';
+import { act, fireEvent, render, RenderResult, screen, waitFor, waitRequests } from '../../testing';
 import { DescriptionStep } from '../../ui/features/projects/ProjectForm/steps';
 
 import {
@@ -235,7 +235,9 @@ describe('CreateProjectPage', () => {
       const spy = jest.spyOn(providers.app.notifications, 'add');
       await waitRequests();
 
-      expect(spy).toBeCalledWith(expect.objectContaining({ body: 'Проект успешно создан' }));
+      await waitFor(() =>
+        expect(spy).toBeCalledWith(expect.objectContaining({ body: 'Проект успешно создан' })),
+      );
 
       await waitRequests();
     });

--- a/src/pages/projects/ProjectsPage.test.tsx
+++ b/src/pages/projects/ProjectsPage.test.tsx
@@ -42,11 +42,15 @@ describe('ProjectsPage', () => {
 
     await waitRequests();
 
-    expect(screen.getByTestId(ProjectsPageView.testId.rootTitle)).toBeVisible();
-    expect(screen.getByTestId(ProjectsPageView.testId.table)).toBeVisible();
-    expect(
-      screen.getByText(defaultMock[1].result.data.projects?.data[2].name as string),
-    ).toBeVisible();
+    await waitFor(() =>
+      expect(screen.getByTestId(ProjectsPageView.testId.rootTitle)).toBeVisible(),
+    );
+    await waitFor(() => expect(screen.getByTestId(ProjectsPageView.testId.table)).toBeVisible());
+    await waitFor(() =>
+      expect(
+        screen.getByText(defaultMock[1].result.data.projects?.data[2].name as string),
+      ).toBeVisible(),
+    );
   });
 
   test('проект помечается избранным', async () => {


### PR DESCRIPTION
## Задача
Задача в Jira GPN: https://jira.konakov.tv/browse/VEGA-3402
stand: http://ltumoyakov-3402-lanit-vega-builder.code013.org

## Solution details

Убран возврат клиентской версии обратно с сервера.

## Type
- [ ] Feature
- [ ] Bug Fix
- [x] Refactoring
- [ ] Test
- [ ] Other

## Associated issues
[shell](https://github.com/gpn-prototypes/vega-shell/pull/218)
[rb](https://github.com/gpn-prototypes/vega-rb/pull/153)
[backend](https://git.konakov.tv/vega2/vega2-back-core/-/merge_requests/503)

## Quality control
- [x] PR: Based on a correct branch
- [x] PR: Head branch is rebased on the base branch
- [x] PR: Assignee chosen and necessary labels are set
- [x] PR: Current form is filled out (where it makes sense)
- [x] PR: Diff checked for irrelevant changes
- [x] PR: Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specs
- [x] PR: Checked for spelling, grammar and typos
- [x] JS: There's no errors/warnings in the browser dev console
- [ ] Layout: Tested with various content amounts
- [ ] Docs: All the important changes and features are described
- [ ] Tests: New unit tests developed
- [ ] Tests: New E2E tests developed
- [x] Tests: Existing unit tests passed successfully
- [x] Tests: Existing E2E tests passed successfully
- [ ] Tests: Manually tested on personal instance

## Notable statements
- [ ] Affects configuration files
- [ ] Brings new packages or updates existing
- [ ] Opened follow-up tasks to resolve

### E2E Suite Jenkins link
http://jenkins-remote-ci-gpn-vega-builder.code013.org:8081/job/STAND-TOOLBOX/job/scenario-tests-on-demand/956/

### E2E Suite Screenshot
![image](https://user-images.githubusercontent.com/21119774/122002348-4cbd0800-cdba-11eb-919d-d6472b3bff87.png)

### Unit Tests Screenshot
![image](https://user-images.githubusercontent.com/21119774/122002925-0c11be80-cdbb-11eb-92d3-d97c47890e12.png)